### PR TITLE
clean-hwr:0.1.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -10,6 +10,7 @@ assignees: ''
 **Template Version:**
 - [ ] 0.1.0
 - [ ] 0.1.1
+- [ ] 0.1.2
 - [ ] X.X.X (please specify)
 
 **Typst Version (if applicable):**

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ on the dashboard and searching for `clean-hwr`.
 
 Alternatively, you can use the CLI to kick this project off using the command
 ```
-typst init @preview/clean-hwr:0.1.1
+typst init @preview/clean-hwr:0.1.2
 ```
 
 Typst will create a new directory with all the files needed to get you started.

--- a/lib.typ
+++ b/lib.typ
@@ -4,6 +4,7 @@
 
   // Main Metadata for the title page
   metadata: (
+    paper_type: [],
     title: [PTB Template],
     student-id: "",
     authors: (),
@@ -131,6 +132,7 @@
 
   // Title settings
   let line-length = 90%
+  text(1em, weight: 700, baseline: -13.5pt, metadata.paper_type)
   line(length: line-length)
   text(2em, weight: 700, metadata.title)
   line(length: line-length)

--- a/template/main.typ
+++ b/template/main.typ
@@ -1,4 +1,4 @@
-#import "@preview/clean-hwr:0.1.1": *
+#import "@preview/clean-hwr:0.1.2": *
 
 // These packages are used to displaying the acronyms and glossaries
 // They need to be imported here so you can use #acr / #gls

--- a/typst.toml
+++ b/typst.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clean-hwr"
-version = "0.1.1"
+version = "0.1.2"
 compiler = "0.13.1"
 entrypoint = "lib.typ"
 repository = "https://github.com/testspieler09/clean-hwr"


### PR DESCRIPTION
- simply added the `paper_type` field
- bumped up the version to `0.1.2`