### PR TITLE
feat(glossarium): add ability to disable back references

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -37,7 +37,8 @@
   // All the lists and outlines
   glossary: (
     title: "",
-    entries: ()
+    entries: (),
+    disable-back-references: false
   ),
   acronyms: (
     title: "",
@@ -317,7 +318,7 @@
     register-glossary(glossary.entries)
 
     heading(glossary.at("title", default: if language == "de" { "Glossar" } else { "Glossary" }), numbering: none)
-    print-glossary(glossary.entries, show-all: true)
+    print-glossary(glossary.entries, show-all: true, disable-back-references: glossary.disable-back-references)
     pagebreak()
   }
 

--- a/lib.typ
+++ b/lib.typ
@@ -38,7 +38,8 @@
   glossary: (
     title: "",
     entries: (),
-    disable-back-references: false
+    disable-back-references: none,
+    // disable-back-references: false
   ),
   acronyms: (
     title: "",
@@ -71,6 +72,7 @@
   body,
 ) = {
   import "@preview/acrostiche:0.6.0": *
+  import "@preview/glossarium:0.5.8": *
 
   set document(author: metadata.authors, title: metadata.title)
   set page(numbering: none, number-align: center)
@@ -81,6 +83,11 @@
   // SETUP Acronyms
   if acronyms.entries != () {
     init-acronyms(acronyms.entries)
+  }
+
+  if glossary.entries != () {
+    show: make-glossary
+    register-glossary(glossary.entries)
   }
 
   // SETUP Title page
@@ -313,12 +320,8 @@
 
   // Glossary
   if glossary.entries != () {
-    import "@preview/glossarium:0.5.8": *
-    show: make-glossary
-    register-glossary(glossary.entries)
-
     heading(glossary.at("title", default: if language == "de" { "Glossar" } else { "Glossary" }), numbering: none)
-    print-glossary(glossary.entries, show-all: true, disable-back-references: glossary.disable-back-references)
+    print-glossary(glossary.entries, show-all: true, disable-back-references: glossary.at("disable-back-references", default: false))
     pagebreak()
   }
 


### PR DESCRIPTION
**Glossary feature enhancements:**

* Added a new `disable-back-references` property to the `glossary` configuration, allowing users to control whether back-references are shown for glossary entries.
* Updated the rendering of the glossary with `print-glossary` to respect the new `disable-back-references` property, passing its value to the function.

**Refactoring and initialization:**

* Moved the import and initialization of the `glossarium` package and glossary registration to the main setup block, ensuring glossary features are initialized only when entries exist. [[1]](diffhunk://#diff-bf166bc8404814a5ce7a74196a13bf9acdd01adfbd27c3f83362cec3726895f9R75) [[2]](diffhunk://#diff-bf166bc8404814a5ce7a74196a13bf9acdd01adfbd27c3f83362cec3726895f9R88-R92)